### PR TITLE
clang14/15/16/17/20: fix FILES paths after BPN change

### DIFF
--- a/recipes-devtools/clang14/clang14_git.bb
+++ b/recipes-devtools/clang14/clang14_git.bb
@@ -346,7 +346,7 @@ FILES:${PN} += "\
   ${libdir}/LLVMHello.so \
   ${libdir}/LLVMgold.so \
   ${libdir}/*Plugin.so \
-  ${libdir}/${BPN} \
+  ${libdir}/clang \
   ${nonarch_libdir}/clang/*/include/ \
   ${datadir}/scan-* \
   ${nonarch_libdir}/libscanbuild \
@@ -384,14 +384,14 @@ FILES:${PN}-dev += "\
   ${datadir}/llvm/cmake \
   ${libdir}/cmake \
   ${nonarch_libdir}/libear \
-  ${nonarch_libdir}/${BPN}/*.la \
+  ${nonarch_libdir}/clang/*.la \
 "
 
-FILES:${PN}-staticdev += "${nonarch_libdir}/${BPN}/*.a"
+FILES:${PN}-staticdev += "${nonarch_libdir}/clang/*.a"
 
-FILES:${PN}-staticdev:remove = "${libdir}/${BPN}/*.a"
-FILES:${PN}-dev:remove = "${libdir}/${BPN}/*.la"
-FILES:${PN}:remove = "${libdir}/${BPN}/*"
+FILES:${PN}-staticdev:remove = "${libdir}/clang/*.a"
+FILES:${PN}-dev:remove = "${libdir}/clang/*.la"
+FILES:${PN}:remove = "${libdir}/clang/*"
 
 
 INSANE_SKIP:${PN} += "already-stripped"

--- a/recipes-devtools/clang15/clang15_git.bb
+++ b/recipes-devtools/clang15/clang15_git.bb
@@ -348,7 +348,7 @@ FILES:${PN} += "\
   ${libdir}/LLVMHello.so \
   ${libdir}/LLVMgold.so \
   ${libdir}/*Plugin.so \
-  ${libdir}/${BPN} \
+  ${libdir}/clang \
   ${nonarch_libdir}/clang/*/include/ \
   ${datadir}/scan-* \
   ${nonarch_libdir}/libscanbuild \
@@ -387,14 +387,14 @@ FILES:${PN}-dev += "\
   ${datadir}/llvm/cmake \
   ${libdir}/cmake \
   ${nonarch_libdir}/libear \
-  ${nonarch_libdir}/${BPN}/*.la \
+  ${nonarch_libdir}/clang/*.la \
 "
 
-FILES:${PN}-staticdev += "${nonarch_libdir}/${BPN}/*.a"
+FILES:${PN}-staticdev += "${nonarch_libdir}/clang/*.a"
 
-FILES:${PN}-staticdev:remove = "${libdir}/${BPN}/*.a"
-FILES:${PN}-dev:remove = "${libdir}/${BPN}/*.la"
-FILES:${PN}:remove = "${libdir}/${BPN}/*"
+FILES:${PN}-staticdev:remove = "${libdir}/clang/*.a"
+FILES:${PN}-dev:remove = "${libdir}/clang/*.la"
+FILES:${PN}:remove = "${libdir}/clang/*"
 
 
 INSANE_SKIP:${PN} += "already-stripped"

--- a/recipes-devtools/clang16/clang16_git.bb
+++ b/recipes-devtools/clang16/clang16_git.bb
@@ -362,7 +362,7 @@ FILES:${PN} += "\
   ${libdir}/BugpointPasses.so \
   ${libdir}/LLVMHello.so \
   ${libdir}/*Plugin.so \
-  ${libdir}/${BPN} \
+  ${libdir}/clang \
   ${nonarch_libdir}/clang/*/include/ \
 "
 
@@ -398,14 +398,14 @@ FILES:${PN}-dev += "\
   ${datadir}/llvm/cmake \
   ${libdir}/cmake \
   ${nonarch_libdir}/libear \
-  ${nonarch_libdir}/${BPN}/*.la \
+  ${nonarch_libdir}/clang/*.la \
 "
 
-FILES:${PN}-staticdev += "${nonarch_libdir}/${BPN}/*.a"
+FILES:${PN}-staticdev += "${nonarch_libdir}/clang/*.a"
 
-FILES:${PN}-staticdev:remove = "${libdir}/${BPN}/*.a"
-FILES:${PN}-dev:remove = "${libdir}/${BPN}/*.la"
-FILES:${PN}:remove = "${libdir}/${BPN}/*"
+FILES:${PN}-staticdev:remove = "${libdir}/clang/*.a"
+FILES:${PN}-dev:remove = "${libdir}/clang/*.la"
+FILES:${PN}:remove = "${libdir}/clang/*"
 
 
 INSANE_SKIP:${PN} += "already-stripped"

--- a/recipes-devtools/clang17/clang17_git.bb
+++ b/recipes-devtools/clang17/clang17_git.bb
@@ -366,7 +366,7 @@ FILES:${PN} += "\
   ${libdir}/BugpointPasses.so \
   ${libdir}/LLVMHello.so \
   ${libdir}/*Plugin.so \
-  ${libdir}/${BPN} \
+  ${libdir}/clang \
   ${nonarch_libdir}/clang/*/include/ \
 "
 
@@ -402,14 +402,14 @@ FILES:${PN}-dev += "\
   ${datadir}/llvm/cmake \
   ${libdir}/cmake \
   ${nonarch_libdir}/libear \
-  ${nonarch_libdir}/${BPN}/*.la \
+  ${nonarch_libdir}/clang/*.la \
 "
 
-FILES:${PN}-staticdev += "${nonarch_libdir}/${BPN}/*.a"
+FILES:${PN}-staticdev += "${nonarch_libdir}/clang/*.a"
 
-FILES:${PN}-staticdev:remove = "${libdir}/${BPN}/*.a"
-FILES:${PN}-dev:remove = "${libdir}/${BPN}/*.la"
-FILES:${PN}:remove = "${libdir}/${BPN}/*"
+FILES:${PN}-staticdev:remove = "${libdir}/clang/*.a"
+FILES:${PN}-dev:remove = "${libdir}/clang/*.la"
+FILES:${PN}:remove = "${libdir}/clang/*"
 
 
 INSANE_SKIP:${PN} += "already-stripped"

--- a/recipes-devtools/clang20/clang20_git.bb
+++ b/recipes-devtools/clang20/clang20_git.bb
@@ -324,7 +324,7 @@ FILES:${PN} += "\
   ${libdir}/BugpointPasses.so \
   ${libdir}/LLVMHello.so \
   ${libdir}/*Plugin.so \
-  ${libdir}/${BPN} \
+  ${libdir}/clang \
   ${nonarch_libdir}/clang/*/include/ \
 "
 
@@ -342,15 +342,15 @@ FILES:${PN}-dev += "\
   ${datadir}/llvm/cmake \
   ${libdir}/cmake \
   ${nonarch_libdir}/libear \
-  ${nonarch_libdir}/${BPN}/*.la \
+  ${nonarch_libdir}/clang/*.la \
 "
 FILES:${PN}-doc += "${datadir}/clang-doc"
 
-FILES:${PN}-staticdev += "${nonarch_libdir}/${BPN}/*.a"
+FILES:${PN}-staticdev += "${nonarch_libdir}/clang/*.a"
 
-FILES:${PN}-staticdev:remove = "${libdir}/${BPN}/*.a"
-FILES:${PN}-dev:remove = "${libdir}/${BPN}/*.la"
-FILES:${PN}:remove = "${libdir}/${BPN}/*"
+FILES:${PN}-staticdev:remove = "${libdir}/clang/*.a"
+FILES:${PN}-dev:remove = "${libdir}/clang/*.la"
+FILES:${PN}:remove = "${libdir}/clang/*"
 
 INSANE_SKIP:${PN} += "already-stripped"
 #INSANE_SKIP:${PN}-dev += "dev-elf"


### PR DESCRIPTION
The clang14, clang15, clang16, clang17, and clang20 recipes are derived from clang_git.bb in meta-clang. As a result, their BPN is versioned (e.g. clang14, clang15), while the installed files are still placed under version-independent paths such as /usr/lib*/clang.

Using ${BPN} in FILES therefore no longer matches the actual install layout, causing installed-but-not-shipped QA errors, for example:

  ERROR: clang14: Files/directories were installed but not shipped:
    /usr/lib64/clang

Replace ${BPN} with the correct hardcoded "clang" directory in FILES to ensure all installed files are properly packaged.