### PR TITLE
ispc: Remove bbappend following upgrade to 1.29.1 in meta-intel

### DIFF
--- a/dynamic-layers/intel/recipes-core/ispc/ispc_%.bbappend
+++ b/dynamic-layers/intel/recipes-core/ispc/ispc_%.bbappend
@@ -1,7 +1,0 @@
-DEPENDS:remove = "clang-native"
-DEPENDS:append = " clang15-native"
-DEPENDS:remove:class-target = "clang"
-DEPENDS:append:class-target = " clang15"
-
-# ispc-dev will omit clang15-dev and others this way
-RRECOMMENDS:ispc-dev[nodeprrecs] = "1"


### PR DESCRIPTION
The ispc recipe in meta-intel has been upgraded to version 1.29.1 with bundled LLVM 20.1.8, making the bbappend in meta-clang-revival obsolete.