### PR TITLE
Fix spirv-llvm-translator-llvm15 build

### DIFF
--- a/recipes-graphics/spir/spirv-headers_1.4.309.0.bb
+++ b/recipes-graphics/spir/spirv-headers_1.4.309.0.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Machine-readable files for the SPIR-V Registry"
+SECTION = "graphics"
+HOMEPAGE = "https://www.khronos.org/registry/spir-v"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d14ee3b13f42e9c9674acc5925c3d741"
+
+SRCREV = "09913f088a1197aba4aefd300a876b2ebbaa3391"
+SRC_URI = "git://github.com/KhronosGroup/SPIRV-Headers;protocol=https;branch=main"
+PE = "1"
+# These recipes need to be updated in lockstep with each other:
+# glslang, vulkan-headers, vulkan-loader, vulkan-tools, spirv-headers, spirv-tools
+# vulkan-validation-layers, vulkan-utility-libraries, vulkan-volk.
+# The tags versions should always be sdk-x.y.z, as this is what
+# upstream considers a release.
+UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-graphics/spir/spirv-tools_1.4.309.0.bb
+++ b/recipes-graphics/spir/spirv-tools_1.4.309.0.bb
@@ -1,0 +1,53 @@
+SUMMARY  = "The SPIR-V Tools project provides an API and commands for \
+processing SPIR-V modules"
+DESCRIPTION = "The project includes an assembler, binary module parser, \
+disassembler, validator, and optimizer for SPIR-V."
+HOMEPAGE = "https://github.com/KhronosGroup/SPIRV-Tools"
+SECTION = "graphics"
+LICENSE  = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+SRCREV = "f289d047f49fb60488301ec62bafab85573668cc"
+SRC_URI = "git://github.com/KhronosGroup/SPIRV-Tools.git;branch=main;protocol=https \
+           "
+PE = "1"
+# These recipes need to be updated in lockstep with each other:
+# glslang, vulkan-headers, vulkan-loader, vulkan-tools, spirv-headers, spirv-tools
+# vulkan-validation-layers, vulkan-utility-libraries, vulkan-volk.
+# The tags versions should always be sdk-x.y.z, as this is what
+# upstream considers a release.
+UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+DEPENDS = "spirv-headers"
+
+EXTRA_OECMAKE += "\
+    -DSPIRV-Headers_SOURCE_DIR=${STAGING_EXECPREFIXDIR} \
+    -DSPIRV_TOOLS_BUILD_STATIC=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DSPIRV_SKIP_TESTS=ON \
+"
+
+# Force the version description "git describe" related non-reproducibility
+do_compile:prepend() {
+    export FORCED_BUILD_VERSION_DESCRIPTION="${PV}"
+}
+
+do_install:append:class-target() {
+    # Properly set _IMPORT_PREFIX in INTERFACE_LINK_LIBRARIES so that dependent
+    # tools can find the right library
+    sed -i ${D}${libdir}/cmake/SPIRV-Tools/SPIRV-ToolsTarget.cmake \
+        -e 's:INTERFACE_LINK_LIBRARIES.*$:INTERFACE_LINK_LIBRARIES "\$\{_IMPORT_PREFIX\}/${baselib}":'
+}
+
+# all the libraries are unversioned, so don't pack it on PN-dev
+SOLIBS = ".so"
+FILES_SOLIBSDEV = ""
+
+PACKAGES =+ "${PN}-lesspipe"
+FILES:${PN}-lesspipe = "${base_bindir}/spirv-lesspipe.sh"
+RDEPENDS:${PN}-lesspipe += "${PN} bash"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Fixes #6 

I too had compilation issues with spirv-llvm-translator-llvm15 on scarthgap. 
poky @ scarthgap provides spriv v1.3.275.0 which causes these build issues.
This PR adds the updated v1.4.309.0 recipes to the scarthgap branch of this layer.

spriv-* recipes taken from [poky@walnascar (03b7d0afcbec84d2e7a347179b15982f4a975021) ](https://github.com/yoctoproject/poky/tree/03b7d0afcbec84d2e7a347179b15982f4a975021/meta/recipes-graphics/spir)